### PR TITLE
Add Ubuntu 18.04 VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ OpenVPN on them. Both OpenSSL and MbedTLS builds are supported out of the box:
 * openbsd-6
 * solaris-113
 * ubuntu-1604
+* ubuntu-1804
 
 Note that it is not possible to legally distribute the base box for solaris-113; 
 please refer to [recipes/Solaris113.txt](recipes/Solaris113.txt) for details.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,4 +108,18 @@ Vagrant.configure("2") do |config|
       vb.memory = 768
     end
   end
+
+  config.vm.define "ubuntu-1804" do |box|
+    box.vm.box = "ubuntu/bionic64"
+    box.vm.box_version = "20180823.0.0"
+    box.vm.hostname = "ubuntu-1804.local"
+    box.vm.network "private_network", ip: "192.168.48.109"
+    box.vm.provision "shell", path: "ubuntu-1604.sh"
+    box.vm.provision "shell", path: "install-mbedtls.sh"
+    box.vm.provision "shell", path: "install-fping.sh"
+    box.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.memory = 768
+    end
+  end
 end


### PR DESCRIPTION
Creating the VM requires a relatively recent version of Vagrant because of [this Vagrant bug](https://github.com/hashicorp/vagrant/issues/9134). The latest version of Vagrant (2.1.3) seemed to work well.

Provisioning scripts work fine, as do both OpenSSL and mbedTLS build of OpenVPN 2.x.