### PR TITLE
Add sbuild and Debian 10 boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ OpenVPN on them. Both OpenSSL and MbedTLS builds are supported out of the box:
 
 * centos-7
 * debian-9
+* debian-10
 * freebsd-11
 * netbsd-7
 * openbsd-6

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -137,6 +137,13 @@ Vagrant.configure("2") do |config|
       s.path = "setup-generic-buildsystem.sh"
       s.args = ["-f"]
     end
+
+    config.vm.define "sbuild" do |box|
+    box.vm.box = "ubuntu/bionic64"
+    box.vm.box_version = "20180823.0.0"
+    box.vm.hostname = "sbuild.local"
+    box.vm.network "private_network", ip: "192.168.48.111"
+    box.vm.provision "shell", path: "sbuild.sh"
     box.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.memory = 1024

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -137,8 +137,9 @@ Vagrant.configure("2") do |config|
       s.path = "setup-generic-buildsystem.sh"
       s.args = ["-f"]
     end
+  end
 
-    config.vm.define "sbuild" do |box|
+  config.vm.define "sbuild" do |box|
     box.vm.box = "ubuntu/bionic64"
     box.vm.box_version = "20180823.0.0"
     box.vm.hostname = "sbuild.local"
@@ -147,6 +148,19 @@ Vagrant.configure("2") do |config|
     box.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.memory = 1024
+    end
+  end
+
+  config.vm.define "debian-10" do |box|
+    box.vm.box = "debian/contrib-buster64"
+    box.vm.box_version = "10.3.0"
+    box.vm.hostname = "debian-10.local"
+    box.vm.network "private_network", ip: "192.168.48.112"
+    box.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+    box.vm.provision "shell", path: "debian-10.sh"
+    box.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.memory = 768
     end
   end
 end

--- a/debian-10.sh
+++ b/debian-10.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Updating package cache"
+apt-get update
+echo
+echo "Preparing OpenVPN 2 build environment"
+echo
+apt-get -y install liblzo2-dev libssl-dev libpam-dev libpkcs11-helper1-dev libtool autoconf make cmake git fping net-tools liblz4-dev
+echo
+echo "Preparing OpenVPN 3 build environment"
+apt-get -y install pkg-config autoconf libglib2.0-dev libjsoncpp-dev uuid-dev libmbedtls-dev liblz4-dev build-essential

--- a/sbuild.sh
+++ b/sbuild.sh
@@ -1,0 +1,16 @@
+echo "Updating package cache"
+apt-get update
+echo
+echo "Installing sbuild_wrapper dependencies"
+apt-get -y install sbuild git quilt debhelper
+echo
+echo "Cloning sbuild_wrapper if not present"
+test -d sbuild_wrapper || git clone --branch fixes https://github.com/mattock/sbuild_wrapper.git
+echo
+echo "Setting up sbuild_wrapper and schroots"
+cd sbuild_wrapper
+scripts/setup.sh
+scripts/setup_chroots.sh
+scripts/install-build-deps.sh
+scripts/update-all.sh
+scripts/prepare-all.sh

--- a/setup-generic-buildsystem.sh
+++ b/setup-generic-buildsystem.sh
@@ -5,7 +5,7 @@
 # This script works on Ubuntu 16.04 and 18.04.
 
 CODENAME=`lsb_release -cs`
-BUILD_DEPS="mingw-w64 man2html dos2unix nsis unzip wget curl autoconf libtool gcc-arm-linux-gnueabi"
+BUILD_DEPS="libpam0g-dev mingw-w64 man2html dos2unix nsis unzip wget curl autoconf libtool gcc-arm-linux-gnueabi"
 OSSLSIGNCODE_URL="http://sourceforge.net/projects/osslsigncode/files/latest/download"
 OSSLSIGNCODE_PACKAGE="osslsigncode-latest.tar.gz"
 OPENVPN_BUILD_URL="https://github.com/OpenVPN/openvpn-build.git"


### PR DESCRIPTION
The former is used to build OpenVPN 2.x Debian/Ubuntu packages and the latter for generic OpenVPN 2/3 builds.