### PR TITLE
buildmaster: fix errors in master.cfg

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -55,9 +55,9 @@ docker_host = master_config.get("docker", "host", raw=True)
 docker_network = master_config.get("docker", "network")
 
 # OpenVPN 2 settings
-openvpn_repo_url = master_config.get("openvpn", "repo_url")
-openvpn_branch = master_config.get("openvpn", "branch")
-openvpn_run_tclient_tests = master_config.get("openvpn", "run_tclient_tests")
+openvpn_repo_url = master_config.get("master", "repo_url")
+openvpn_branch = master_config.get("master", "branch")
+openvpn_run_tclient_tests = master_config.get("master", "run_tclient_tests")
 
 # Each section in worker.ini represents one buildbot worker. The "DEFAULT"
 # section gives the default settings and gets filtered out automatically, i.e.
@@ -227,7 +227,7 @@ for factory_name, factory in factories.items():
       builder_names.append(builder_name)
 
 c['services'] = []
-c['title'] = "OpenVPN community buildbot"
+c['title'] = "OpenVPN Buildbot"
 c['titleURL'] = title_url
 c['buildbotURL'] = buildbot_url
 c['www'] = {


### PR DESCRIPTION
- Referred to non-existant config section
- Title can at most have length 18. Otherwise we get
  `ConfigWarning: WARNING: Title is too long to be displayed.
   "Buildbot" will be used instead.`